### PR TITLE
Support optional caller-specified player IDs during creation of YouTubeMusicClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .vs/
+.idea/
 packages/
 
 *.suo
 *.user
+*.DS_Store
 _ReSharper.*
 
 Development/

--- a/YouTubeMusicAPI.Tests/TestData.cs
+++ b/YouTubeMusicAPI.Tests/TestData.cs
@@ -21,7 +21,7 @@ internal abstract class TestData
     /// Test po token for requests
     /// </summary>
     public const string? PoToken = null;
-
+        
     /// <summary>
     /// Test cookies for authentication
     /// </summary>
@@ -30,7 +30,7 @@ internal abstract class TestData
         get
         {
             string? cookies = null;
-
+                
             return cookies?
                 .Split(';')
                 .Select(cookieString =>
@@ -49,12 +49,12 @@ internal abstract class TestData
 
 
     /// <summary>
-    /// Test offset from which items should be retruened for fetch requests
+    /// Test offset from which items should be returned for fetch requests
     /// </summary>
     public const int FetchOffset = 0;
 
     /// <summary>
-    /// Test maximum items of items which should be retruened for fetch requests
+    /// Test maximum items of items which should be returned for fetch requests
     /// </summary>
     public const int FetchLimit = 20;
 
@@ -100,5 +100,5 @@ internal abstract class TestData
     /// <summary>
     /// File path to download test media stream
     /// </summary>
-    public static string FilePath = @$"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\test.mp4";
+    public static readonly string FilePath = @$"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\test.mp4";
 }

--- a/YouTubeMusicAPI.Tests/TestData.cs
+++ b/YouTubeMusicAPI.Tests/TestData.cs
@@ -62,7 +62,7 @@ internal abstract class TestData
     /// <summary>
     /// Test song or video id
     /// </summary>
-    public const string SongVideoId = "3b97cGKN_1A";
+    public const string SongVideoId = "MLKBxET5Lzg";
 
     /// <summary>
     /// Test album id

--- a/YouTubeMusicAPI.Tests/TestData.cs
+++ b/YouTubeMusicAPI.Tests/TestData.cs
@@ -1,0 +1,104 @@
+﻿using System.Net;
+
+namespace YouTubeMusicAPI.Tests;
+
+/// <summary>
+/// Contains test data for tests
+/// </summary>
+internal abstract class TestData
+{
+    /// <summary>
+    /// Test geographical location for requests
+    /// </summary>
+    public const string GeographicalLocation = "US";
+
+    /// <summary>
+    /// Test visitor data for requests
+    /// </summary>
+    public const string? VisitorData = null;
+
+    /// <summary>
+    /// Test po token for requests
+    /// </summary>
+    public const string? PoToken = null;
+
+    /// <summary>
+    /// Test cookies for authentication
+    /// </summary>
+    public static IEnumerable<Cookie>? Cookies
+    {
+        get
+        {
+            string? cookies = null;
+
+            return cookies?
+                .Split(';')
+                .Select(cookieString =>
+                {
+                    string[] parts = cookieString.Split("=");
+                    return new Cookie(parts[0], parts[1]) { Domain = ".youtube.com" };
+                }) ?? null;
+        }
+    }
+
+
+    /// <summary>
+    /// Test query for search requests
+    /// </summary>
+    public const string SearchQuery = "Pashanim";
+
+
+    /// <summary>
+    /// Test offset from which items should be retruened for fetch requests
+    /// </summary>
+    public const int FetchOffset = 0;
+
+    /// <summary>
+    /// Test maximum items of items which should be retruened for fetch requests
+    /// </summary>
+    public const int FetchLimit = 20;
+
+
+    /// <summary>
+    /// Test song or video id
+    /// </summary>
+    public const string SongVideoId = "3b97cGKN_1A";
+
+    /// <summary>
+    /// Test album id
+    /// </summary>
+    public const string AlbumId = "OLAK5uy_muEnh0WPCqRdkgV3Qg24ttvmZTP1_RBTo";
+
+    /// <summary>
+    /// Test playlist id
+    /// </summary>
+    public const string PlaylistId = "PLuvXOFt0CoEbwWSQj5LmzPhIVKS0SvJ-1";
+
+
+    /// <summary>
+    /// Test album browse id
+    /// </summary>
+    public const string AlbumBrowseId = "MPREb_H2RWN4XY0Ny";
+
+    /// <summary>
+    /// Test playlist browse id
+    /// </summary>
+    public const string PlaylistBrowseId = "RDAMVMnP4Q-iszqb0";
+
+    /// <summary>
+    /// Test artist browse id
+    /// </summary>
+    public const string ArtistBrowseId = "UC5_H9CxsfukWbjYeYepADsw";
+
+
+    /// <summary>
+    /// Test watch time for update requests
+    /// </summary>
+    public static TimeSpan WatchTime = TimeSpan.FromMinutes(1.2);
+
+
+    /// <summary>
+    /// File path to download test media stream
+    /// </summary>
+    public static string FilePath = @$"{Environment.GetFolderPath(Environment.SpecialFolder.Desktop)}\test.mp4";
+}

--- a/YouTubeMusicAPI/Client/YouTubeMusicBase.cs
+++ b/YouTubeMusicAPI/Client/YouTubeMusicBase.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System.Collections.Specialized;
-using System.Net;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Web;
 using YouTubeMusicAPI.Internal;
 

--- a/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
+++ b/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
@@ -78,7 +78,7 @@ public class YouTubeMusicClient
         isCookieAuthenticated = cookies is not null;
 
         this.logger = logger;
-        this.requestHelper = new(httpClient ?? new(), cookies);
+        this.requestHelper = new(logger, httpClient ?? new(), cookies);
         this.baseClient = new(logger, requestHelper);
 
         logger?.LogInformation($"[YouTubeMusicClient-.ctor] YouTubeMusicClient with extendended logging functions has been initialized.");

--- a/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
+++ b/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
@@ -693,7 +693,7 @@ public class YouTubeMusicClient
             }
 
             // Send request
-            Dictionary<string, object> payload = Payload.WebRemix(GeographicalLocation, VisitorData, PoToken, player.Algorithms.SigTimestamp,
+            Dictionary<string, object> payload = Payload.WebRemix(GeographicalLocation, VisitorData, PoToken, player.SignatureTimestamp,
                 [
                     ("videoId", id)
                 ]);

--- a/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
+++ b/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
@@ -693,7 +693,7 @@ public class YouTubeMusicClient
             }
 
             // Send request
-            Dictionary<string, object> payload = Payload.WebRemix(GeographicalLocation, VisitorData, PoToken, player.SigTimestamp,
+            Dictionary<string, object> payload = Payload.WebRemix(GeographicalLocation, VisitorData, PoToken, player.Algorithms.SigTimestamp,
                 [
                     ("videoId", id)
                 ]);

--- a/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
+++ b/YouTubeMusicAPI/Client/YouTubeMusicClient.cs
@@ -24,8 +24,10 @@ public class YouTubeMusicClient
     readonly YouTubeMusicBase baseClient;
 
     readonly bool isCookieAuthenticated;
+    readonly string? playerId;
 
     Player? player = null;
+    readonly SemaphoreSlim playerSemaphore;
 
     /// <summary>
     /// Creates a new search client
@@ -35,12 +37,14 @@ public class YouTubeMusicClient
     /// <param name="poToken">The Proof of Origin Token for attestation (may be required for streaming)</param>
     /// <param name="cookies">Initial cookies used for authentication</param>
     /// <param name="httpClient">Http client which handles sending requests</param>
+    /// <param name="playerId">Optional player id; if empty, derive the most recent player id from the iframe API</param>
     public YouTubeMusicClient(
         string geographicalLocation = "US",
         string? visitorData = null,
         string? poToken = null,
         IEnumerable<Cookie>? cookies = null,
-        HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        string? playerId = null)
     {
         GeographicalLocation = geographicalLocation;
         VisitorData = visitorData;
@@ -50,6 +54,8 @@ public class YouTubeMusicClient
 
         this.requestHelper = new(httpClient ?? new(), cookies);
         this.baseClient = new(requestHelper);
+        this.playerSemaphore = new SemaphoreSlim(1, 1);
+        this.playerId = playerId;
 
         logger?.LogInformation($"[YouTubeMusicClient-.ctor] YouTubeMusicClient has been initialized.");
     }
@@ -69,7 +75,8 @@ public class YouTubeMusicClient
         string? visitorData = null,
         string? poToken = null,
         IEnumerable<Cookie>? cookies = null,
-        HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        string? playerId = null)
     {
         GeographicalLocation = geographicalLocation;
         VisitorData = visitorData;
@@ -80,6 +87,8 @@ public class YouTubeMusicClient
         this.logger = logger;
         this.requestHelper = new(logger, httpClient ?? new(), cookies);
         this.baseClient = new(logger, requestHelper);
+        this.playerSemaphore = new SemaphoreSlim(1, 1);
+        this.playerId = playerId;
 
         logger?.LogInformation($"[YouTubeMusicClient-.ctor] YouTubeMusicClient with extendended logging functions has been initialized.");
     }
@@ -686,10 +695,18 @@ public class YouTubeMusicClient
         }
         else // Mobile client does not support cookie authentication -> falling back to WebRemix client
         {
-            if (player is null)
+            await playerSemaphore.WaitAsync(cancellationToken);
+            try
             {
-                logger?.LogInformation("[YouTubeMusicClient-GetStreamingDataAsync] Creating required player for streaming...");
-                player = await Player.CreateAsync(requestHelper, PoToken, cancellationToken);
+                if (player is null)
+                {
+                    logger?.LogInformation("[YouTubeMusicClient-GetStreamingDataAsync] Creating required player for streaming...");
+                    player = await Player.CreateAsync(requestHelper, PoToken, playerId, cancellationToken);
+                }
+            }
+            finally
+            {
+                playerSemaphore.Release();
             }
 
             // Send request

--- a/YouTubeMusicAPI/Internal/Extensions.cs
+++ b/YouTubeMusicAPI/Internal/Extensions.cs
@@ -43,7 +43,7 @@ internal static class Extensions
             "Songs" => SearchCategory.Songs,
             "Videos" => SearchCategory.Videos,
             "Albums" => SearchCategory.Albums,
-            "Community playlists" => SearchCategory.CommunityPlaylists,
+            "Community playlists" or "Playlists" => SearchCategory.CommunityPlaylists,
             "Artists" => SearchCategory.Artists,
             "Podcasts" => SearchCategory.Podcasts,
             "Episodes" => SearchCategory.Episodes,

--- a/YouTubeMusicAPI/Internal/Extensions.cs
+++ b/YouTubeMusicAPI/Internal/Extensions.cs
@@ -114,42 +114,36 @@ internal static class Extensions
 
 
     /// <summary>
-    /// Tries to get the fucntion name and code from a node
+    /// Gets the string between two strings
+    /// </summary>
+    /// <param name="value">The source string</param>
+    /// <param name="start">The string for the start index</param>
+    /// <param name="end">The string for the end index</param>
+    /// <returns>The string</returns>
+    public static string? GetStringBetween(
+        this string value,
+        string start,
+        string end)
+    {
+        int startIndex = value.IndexOf(start);
+        if (startIndex == -1)
+            return null;
+
+        int endIndex = value.IndexOf(end, startIndex + start.Length);
+        if (endIndex == -1)
+            return null;
+
+        return value.Substring(startIndex + start.Length, endIndex - startIndex - start.Length);
+    }
+
+    /// <summary>
+    /// Gets the fucntion code from a node
     /// </summary>
     /// <param name="value">The node to parse</param>
     /// <param name="fullJs">The full js containing the node</param>
-    /// <param name="name">The name of the function</param>
-    /// <param name="code">The code of the function</param>
     /// <returns>A boolean indicating weither the function was parsed correctly</returns>
-    public static bool TryGetFunctionInfo(
+    public static string GetFunctionCode(
         this Node value,
-        string fullJs,
-        out string? name,
-        out string? code)
-    {
-        switch (value)
-        {
-            case FunctionDeclaration funcDecl when funcDecl.Id is not null:
-                (name, code) = (funcDecl.Id.Name, fullJs.Substring(funcDecl.Start, funcDecl.End - funcDecl.Start));
-                return true;
-
-            case VariableDeclaration varDecl:
-                foreach (VariableDeclarator decl in varDecl.Declarations)
-                {
-                    if (decl.Id is not Identifier id || decl.Init is not FunctionExpression)
-                        continue;
-
-                    (name, code) = (id.Name, fullJs.Substring(decl.Start, decl.End - decl.Start));
-                    return true;
-                }
-                break;
-
-            case ExpressionStatement { Expression: AssignmentExpression { Left: Identifier id, Right: FunctionExpression } }:
-                (name, code) = (id.Name, fullJs.Substring(value.Start, value.End - value.Start));
-                return true;
-        }
-
-        (name, code) = (null, null);
-        return false;
-    }
+        string fullJs) =>
+        fullJs.Substring(value.Start, value.End - value.Start);
 }

--- a/YouTubeMusicAPI/Internal/Extensions.cs
+++ b/YouTubeMusicAPI/Internal/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿using Acornima.Ast;
 using Newtonsoft.Json;
-using System.Linq;
 using System.Text.RegularExpressions;
 using YouTubeMusicAPI.Internal.JavaScript;
 using YouTubeMusicAPI.Models.Search;

--- a/YouTubeMusicAPI/Internal/JavaScript/AstWalker.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/AstWalker.cs
@@ -1,18 +1,22 @@
 ﻿using Acornima.Ast;
+using System.Reflection;
 
 namespace YouTubeMusicAPI.Internal.JavaScript;
 
 internal static class AstWalker
 {
-    public const int CONTINUE = 0;
+    public const int NORMAL = 0;
     public const int STOP = 1;
     public const int SKIP = 2;
+
+    static readonly Dictionary<Type, List<MemberInfo>> AstMembersCache = [];
 
 
     public delegate int AstVisitor(
         Node node,
         Node? parent,
         IReadOnlyList<Node> ancestors);
+
 
     public static void Walk(
         Node root,
@@ -58,14 +62,60 @@ internal static class AstWalker
             stack.Push((node, parent, true));
             ancestors.Add(node);
 
-            List<Node> children = [.. node.ChildNodes];
-            for (int i = children.Count - 1; i >= 0; i--)
-            {
-                Node? child = children[i];
 
-                if (child is not null)
-                    stack.Push((child, node, false));
+            //List<Node> children = [.. node.ChildNodes];       // only the lord knows why this doesnt work
+            //for (int i = children.Count - 1; i >= 0; i--)     // now i gotta do this expensive ahh reflection >:(
+            //{
+            //    Node? child = children[i];
+
+            //    if (child is not null)
+            //        stack.Push((child, node, false));
+            //}
+
+            foreach (MemberInfo member in GetAstMembers(node.GetType())) // todo: optimize this shi
+            {
+                object? value = member switch
+                {
+                    PropertyInfo pi => pi.GetValue(node),
+                    FieldInfo fi => fi.GetValue(node),
+                    _ => null
+                };
+
+                if (value is IEnumerable<Node> nodeEnumerable)
+                {
+                    foreach (Node childNode in nodeEnumerable.Reverse())
+                        if (childNode is not null)
+                            stack.Push((childNode, node, false));
+                }
+                else if (value is Node childNode)
+                    stack.Push((childNode, node, false));
             }
+
         }
+    }
+
+
+    static List<MemberInfo> GetAstMembers(
+        Type type)
+    {
+        if (AstMembersCache.TryGetValue(type, out List<MemberInfo>? cached))
+            return cached;
+
+        List<MemberInfo> members = [.. type
+            .GetMembers(BindingFlags.Instance | BindingFlags.Public)
+            .Where(m => m.MemberType == MemberTypes.Property || m.MemberType == MemberTypes.Field)
+            .Where(p => p.Name != "Start" &&
+                        p.Name != "End" &&
+                        p.Name != "Location" &&
+                        p.Name != "LocationRef" &&
+                        p.Name != "Range" &&
+                        p.Name != "RangeRef" &&
+                        p.Name != "Type" &&
+                        p.Name != "TypeText" &&
+                        p.Name != "UserData" &&
+                        p.Name != "ChildNodes")];
+
+        AstMembersCache[type] = members;
+        return members;
     }
 }

--- a/YouTubeMusicAPI/Internal/JavaScript/AstWalker.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/AstWalker.cs
@@ -1,0 +1,71 @@
+﻿using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal static class AstWalker
+{
+    public const int CONTINUE = 0;
+    public const int STOP = 1;
+    public const int SKIP = 2;
+
+
+    public delegate int AstVisitor(
+        Node node,
+        Node? parent,
+        IReadOnlyList<Node> ancestors);
+
+    public static void Walk(
+        Node root,
+        AstVisitor onEnter,
+        AstVisitor? onLeave = null)
+    {
+        if (root is null)
+            return;
+
+        Stack<(Node Node, Node? Parent, bool Exit)> stack = [];
+        stack.Push((root, null, false));
+
+        List<Node> ancestors = [];
+        bool shouldStop = false;
+
+        while (!shouldStop && stack.Count > 0)
+        {
+            (Node node, Node? parent, bool exit) = stack.Pop();
+
+            if (exit)
+            {
+                if (ancestors.Count > 0)
+                    ancestors.RemoveAt(ancestors.Count - 1);
+
+                if (onLeave is not null && onLeave(node, parent, ancestors) == STOP)
+                    shouldStop = true;
+                continue;
+            }
+
+            if (node is null)
+                continue;
+
+            int enterResult = onEnter(node, parent, ancestors);
+            if (enterResult == STOP)
+            {
+                shouldStop = true;
+                continue;
+            }
+
+            if (enterResult == SKIP)
+                continue;
+
+            stack.Push((node, parent, true));
+            ancestors.Add(node);
+
+            List<Node> children = [.. node.ChildNodes];
+            for (int i = children.Count - 1; i >= 0; i--)
+            {
+                Node? child = children[i];
+
+                if (child is not null)
+                    stack.Push((child, node, false));
+            }
+        }
+    }
+}

--- a/YouTubeMusicAPI/Internal/JavaScript/ExtractionState.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/ExtractionState.cs
@@ -1,0 +1,27 @@
+﻿using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal class ExtractionState(
+    (string Name, JsMatchers.Delegate TryMatch, bool CollectDependencies) extractor,
+    Node? node,
+    VariableMetadata? metadata,
+    HashSet<string> dependencies,
+    HashSet<string> dependents,
+    Node? matchContext,
+    bool isReady)
+{
+    public (string Name, JsMatchers.Delegate TryMatch, bool CollectDependencies) Extractor { get; set; } = extractor;
+
+    public Node? Node { get; set; } = node;
+
+    public VariableMetadata? Metadata { get; set; } = metadata;
+
+    public HashSet<string> Dependencies { get; set; } = dependencies;
+
+    public HashSet<string> Dependents { get; set; } = dependents;
+
+    public Node? MatchContext { get; set; } = matchContext;
+
+    public bool IsReady { get; set; } = isReady;
+}

--- a/YouTubeMusicAPI/Internal/JavaScript/JsAnalyzer.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsAnalyzer.cs
@@ -251,7 +251,7 @@ internal class JsAnalyzer
                     {
                         if (prop is RestElement rest)
                             CollectBindingIdentifiers(rest.Argument, target);
-                        else if(prop is Property property)
+                        else if (prop is Property property)
                             CollectBindingIdentifiers(property.Value, target);
                     }
                     break;
@@ -294,7 +294,7 @@ internal class JsAnalyzer
                             scopeStack[scopeStack.Count - 1].Names.Add(functionName);
 
                         Scope functionScope = new([], "function");
-                        if (function is FunctionExpression &&  functionName is not null)
+                        if (function is FunctionExpression && functionName is not null)
                             functionScope.Names.Add(functionName);
 
                         CollectParams(function, functionScope.Names);
@@ -351,10 +351,7 @@ internal class JsAnalyzer
                             }
                             else if (memberExpr.Object is Identifier objectId)
                             {
-                                if ((
-                                        DeclaredVariables.TryGetValue(objectId.Name, out VariableMetadata? declaredBaseVariable) ||
-                                        objectId.Name == LifeParamName
-                                    ) &&
+                                if ((DeclaredVariables.TryGetValue(objectId.Name, out VariableMetadata? declaredBaseVariable) || objectId.Name == LifeParamName) &&
                                     !IsInScope(objectId.Name) &&
                                     !BuiltIns.Contains(objectId.Name)
                                     )
@@ -365,7 +362,7 @@ internal class JsAnalyzer
                                     if (DependentsTracker.TryGetValue(full, out HashSet<string> existingTracker))
                                         existingTracker.Add(identifierName);
                                     else
-                                        DependentsTracker[full] = [ identifierName ];
+                                        DependentsTracker[full] = [identifierName];
                                 }
                             }
                             return AstWalker.NORMAL;
@@ -383,11 +380,8 @@ internal class JsAnalyzer
                             if (DependentsTracker.TryGetValue(identifier.Name, out HashSet<string> existingTracker))
                                 existingTracker.Add(identifierName);
                             else
-                            {
                                 DependentsTracker[identifier.Name] = [identifierName];
-                            }
                         }
-
                         break;
                 }
                 return AstWalker.NORMAL;

--- a/YouTubeMusicAPI/Internal/JavaScript/JsAnalyzer.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsAnalyzer.cs
@@ -3,7 +3,7 @@ using Acornima.Ast;
 
 namespace YouTubeMusicAPI.Internal.JavaScript;
 
-internal class JsExtractor
+internal class JsAnalyzer
 {
     class ExtractionState(
         (string Name, JsMatchers.Delegate TryMatch, bool CollectDependencies) extractor,
@@ -81,11 +81,12 @@ internal class JsExtractor
 
     readonly Script ast;
 
-    string? lifeParamName = null;
-    Dictionary<string, VariableMetadata> declaredVariables = [];
-    Dictionary<string, HashSet<string>> dependentsTracker = [];
+    readonly Dictionary<string, VariableMetadata> declaredVariables = [];
+    readonly Dictionary<string, HashSet<string>> dependentsTracker = [];
 
-    public JsExtractor(
+    string? lifeParamName = null;
+
+    public JsAnalyzer(
         string source,
         (string FucntionName, JsMatchers.Delegate TryMatch, bool CollectDependencies)[] extractors)
     {

--- a/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
@@ -121,10 +121,7 @@ internal class JsExtractor(
 
             case NewExpression newExpr:
                 if (newExpr.Callee is Identifier newExprCalleeId &&
-                    (
-                        JsAnalyzer.BuiltIns.Contains(newExprCalleeId.Name) ||
-                        !isStrictMode
-                    ))
+                    (JsAnalyzer.BuiltIns.Contains(newExprCalleeId.Name) || !isStrictMode))
                     return AreSafeArgs(newExpr.Arguments);
 
                 return false;
@@ -198,6 +195,7 @@ internal class JsExtractor(
             LogicalExpression => "{}",
 
             ArrayExpression => "[]",
+
             _ => "undefined",
         };
 
@@ -388,7 +386,7 @@ internal class JsExtractor(
             }
         }
 
-        // export raw values: ALWAYS TRUE WUHWUHWUHWUHW
+        // export raw values: ALWAYS TRUE WUHWUHWUHWUHW (? im going crazy)
         string rawJson = JsonConvert.SerializeObject(exportedRawValues, Formatting.Indented);
         string[] rawJsonLines = rawJson.Split('\n');
 

--- a/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
@@ -1,0 +1,559 @@
+﻿using Acornima;
+using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal class JsExtractor
+{
+    class ExtractionState(
+        (string Name, JsMatchers.Delegate TryMatch, bool CollectDependencies) extractor,
+        Node? node,
+        VariableMetadata? metadata,
+        HashSet<string> dependencies,
+        HashSet<string> dependents,
+        Node? matchContext,
+        bool isReady)
+    {
+        public (string Name, JsMatchers.Delegate TryMatch, bool CollectDependencies) Extractor { get; set; } = extractor;
+
+        public Node? Node { get; set; } = node;
+
+        public VariableMetadata? Metadata { get; set; } = metadata;
+
+        public HashSet<string> Dependencies { get; set; } = dependencies;
+
+        public HashSet<string> Dependents { get; set; } = dependents;
+
+        public Node? MatchContext { get; set; } = matchContext;
+
+        public bool IsReady { get; set; } = isReady;
+    }
+
+    class VariableMetadata(
+        string name,
+        Node? node,
+        HashSet<string> dependencies,
+        HashSet<string> dependents,
+        bool isPredeclared)
+    {
+        public string Name { get; set; } = name;
+
+        public Node? Node { get; set; } = node;
+
+        public HashSet<string> Dependencies { get; set; } = dependencies;
+
+        public HashSet<string> Dependents { get; set; } = dependents;
+
+        public bool IsPredeclared { get; set; } = isPredeclared;
+    }
+
+    class Scope(
+        HashSet<string> names,
+        string type)
+    {
+        public HashSet<string> Names { get; set; } = names;
+
+        public string Type { get; set; } = type;
+    }
+
+
+    static readonly HashSet<string> JsBuiltIns =
+    [
+        "AbortController", "AbortSignal", "Array", "ArrayBuffer", "AsyncContext", "Atomics", "AudioContext", "BigInt", "BigInt64Array", "BigUint64Array",
+        "Blob", "Boolean", "BroadcastChannel", "Buffer", "CanvasRenderingContext2D", "clearImmediate", "clearInterval", "clearTimeout", "confirm",
+        "console", "Crypto", "CustomEvent", "DataView", "Date", "decodeURI", "decodeURIComponent", "document", "Element", "encodeURI",
+        "encodeURIComponent", "Error", "escape", "eval", "Event", "EventTarget", "fetch", "File", "FileReader", "Float32Array", "Float64Array",
+        "FormData", "function", "global", "globalThis", "hasOwnProperty", "Headers", "History", "HTMLElement", "HTMLCollection", "IDBKeyRange",
+        "Infinity", "Int16Array", "Int32Array", "Int8Array", "Intl", "IntersectionObserver", "isFinite", "isNaN", "isPrototypeOf", "JSON",
+        "location", "log", "Map", "Math", "MediaRecorder", "MediaSource", "MediaStream", "MemberExpression", "MutationObserver", "NaN",
+        "navigator", "Node", "NodeList", "Number", "Object", "OfflineAudioContext", "parse", "parseFloat", "parseInt", "Performance",
+        "process", "Promise", "prompt", "prototype", "Proxy", "ReadableStream", "Reflect", "RegExp", "requestAnimationFrame", "requestIdleCallback",
+        "Request", "Response", "ResizeObserver", "Screen", "setImmediate", "setInterval", "setTimeout", "SharedArrayBuffer", "SharedWorker",
+        "SourceBuffer", "split", "String", "stringify", "structuredClone", "SubtleCrypto", "Symbol", "TextDecoder", "TextEncoder", "this",
+        "toString", "TransformStream", "Uint16Array", "Uint32Array", "Uint8Array", "Uint8ClampedArray", "undefined", "unescape", "URL",
+        "URLSearchParams", "valueOf", "WeakMap", "WeakSet", "WebAssembly", "WebGLRenderingContext", "window", "Worker", "WritableStream",
+        "XMLHttpRequest", "alert", "arguments", "atob", "btoa", "cancelAnimationFrame", "cancelIdleCallback", "queueMicrotask"
+    ];
+
+
+    readonly string source;
+    readonly ExtractionState[] extractionStates;
+
+    readonly Script ast;
+
+    string? lifeParamName = null;
+    Dictionary<string, VariableMetadata> declaredVariables = [];
+    Dictionary<string, HashSet<string>> dependentsTracker = [];
+
+    public JsExtractor(
+        string source,
+        (string FucntionName, JsMatchers.Delegate TryMatch, bool CollectDependencies)[] extractors)
+    {
+        this.source = source;
+
+        extractionStates = [.. extractors
+            .Select(extractor => new ExtractionState(
+                extractor,
+                null,
+                null,
+                [],
+                [],
+                null,
+                false))];
+
+        ast = new Parser().ParseScript(source);
+        AnalyzeAst();
+    }
+
+    void AnalyzeAst()
+    {
+        BlockStatement? lifeBody = null;
+        foreach (Statement statement in ast.Body)
+        {
+            if (statement is not ExpressionStatement expressionStmt ||
+                expressionStmt.Expression is not CallExpression callExpr ||
+                callExpr.Callee is not FunctionExpression functionExpr)
+                continue;
+
+            Node? firstParam = functionExpr.Params.FirstOrDefault();
+
+            if (lifeParamName is null && firstParam is Identifier identifier)
+                lifeParamName = identifier.Name;
+
+            if (functionExpr.Body is BlockStatement blockStmt)
+            {
+                lifeBody = blockStmt;
+                break;
+            }
+        }
+
+        if (lifeBody is null)
+            return;
+
+        foreach (Node currentNode in lifeBody.Body)
+        {
+            switch (currentNode)
+            {
+                case VariableDeclaration variableDecl:
+                    foreach (VariableDeclarator declaration in variableDecl.Declarations)
+                    {
+                        if (declaration.Id is not Identifier declerationId)
+                            continue;
+
+                        VariableMetadata metadata = new(
+                            declerationId.Name,
+                            declaration,
+                            dependentsTracker.TryGetValue(declerationId.Name, out HashSet<string> dependents) ? dependents : [],
+                            [],
+                            false);
+
+                        Expression? init = declaration.Init;
+
+                        if (init is null && variableDecl.Kind == VariableDeclarationKind.Var)
+                            metadata.IsPredeclared = true;
+                        else if (init is not null && NeedsDependencyAnalysis(init))
+                            metadata.Dependents = FindDependencies(init, metadata.Name);
+
+                        dependentsTracker.Remove(metadata.Name);
+                        declaredVariables.Add(metadata.Name, metadata);
+
+                        if (TryMatch(declaration, metadata))
+                            return;
+                    }
+                    break;
+
+                case ExpressionStatement expressionStmt:
+                    if (expressionStmt.Expression is not AssignmentExpression assignmentExpr)
+                        continue;
+
+                    if (assignmentExpr.Left is Identifier leftId)
+                    {
+                        if (!declaredVariables.TryGetValue(leftId.Name, out VariableMetadata existingVariable))
+                            continue;
+
+                        if (existingVariable.Node is VariableDeclarator variableDecl)                               // holy shit, luan wtf did u do here?? this a hack frfr
+                            existingVariable.Node = new VariableDeclarator(variableDecl.Id, assignmentExpr.Right);  // why u manually overwriting the init; breaks the entire node code lookup
+
+                        if (NeedsDependencyAnalysis(assignmentExpr.Right))
+                            existingVariable.Dependencies = FindDependencies(assignmentExpr.Right, leftId.Name);
+
+                        if (existingVariable.Node is not null && TryMatch(existingVariable.Node, existingVariable))
+                            return;
+                    }
+                    else if (assignmentExpr.Left is MemberExpression memberExpr)
+                    {
+                        string? memberName = memberExpr.MemberToString(source);
+
+                        if (memberName is null || declaredVariables.ContainsKey(memberName))
+                            continue;
+
+                        VariableMetadata metadata = new(
+                            memberName,
+                            currentNode,
+                            FindDependencies(assignmentExpr.Right, memberName),
+                            dependentsTracker.TryGetValue(memberName, out HashSet<string> dependents) ? dependents : [],
+                            false);
+
+                        string? baseName = memberExpr.MemberBaseName(source);
+                        if (baseName is not null && baseName != memberName && !baseName.StartsWith("this."))
+                            metadata.Dependencies.Add(baseName.Replace(".prototype", ""));
+
+                        dependentsTracker.Remove(memberName);
+                        declaredVariables.Add(memberName, metadata);
+
+                        if (TryMatch(currentNode, metadata))
+                            return;
+                    }
+                    break;
+            }
+        }
+    }
+
+
+    bool NeedsDependencyAnalysis(
+        Node node) =>
+        node switch
+        {
+            FunctionExpression or
+            ArrowFunctionExpression or
+            ArrayExpression or
+            LogicalExpression or
+            CallExpression or
+            NewExpression or
+            MemberExpression or
+            BinaryExpression or
+            ConditionalExpression or
+            ObjectExpression or
+            SequenceExpression or
+            Identifier => true,
+
+            _ => false,
+        };
+
+    HashSet<string> FindDependencies(
+        Node node,
+        string identifierName)
+    {
+        Stack<Scope> scopeStack = [];
+        scopeStack.Push(new([], "block"));
+
+        bool IsInScope(
+            string name)
+        {
+            foreach (Scope scope in scopeStack)
+            {
+                if (scope.Names.Contains(name))
+                    return true;
+            }
+            return false;
+        }
+
+
+        string? rootIdentifierName = node switch
+        {
+            IFunction fn when fn.Id is Identifier id => id.Name,
+            IClass cls when cls.Id is Identifier id => id.Name,
+            VariableDeclarator vd when vd.Id is Identifier id => id.Name,
+            _ => null
+        };
+
+        void CollectBindingIdentifiers(
+            Node? pattern,
+            HashSet<string> target)
+        {
+            if (pattern is null)
+                return;
+
+            switch (pattern)
+            {
+                case Identifier id:
+                    target.Add(id.Name);
+                    break;
+
+                case ObjectPattern objPattern:
+                    foreach (Node prop in objPattern.Properties)
+                    {
+                        if (prop is RestElement rest)
+                            CollectBindingIdentifiers(rest.Argument, target);
+                        else if(prop is Property property)
+                            CollectBindingIdentifiers(property.Value, target);
+                    }
+                    break;
+
+                case ArrayPattern arrayPtrn:
+                    foreach (Node? element in arrayPtrn.Elements)
+                        CollectBindingIdentifiers(element, target);
+                    break;
+
+                case RestElement restElmt:
+                    CollectBindingIdentifiers(restElmt.Argument, target);
+                    break;
+
+                case AssignmentPattern assignmentPtrn:
+                    CollectBindingIdentifiers(assignmentPtrn.Left, target);
+                    break;
+            }
+        }
+
+        void CollectParams(
+            IFunction function,
+            HashSet<string> target)
+        {
+            foreach (Node param in function.Params)
+                CollectBindingIdentifiers(param, target);
+        }
+
+
+        HashSet<string> dependencies = [];
+
+        AstWalker.Walk(node,
+            (currentNode, parent, ancestors) =>
+            {
+                switch (currentNode)
+                {
+                    case IFunction function:
+                        string? functionName = function.Id?.Name;
+
+                        if (function is FunctionDeclaration && functionName is not null)
+                            scopeStack.Peek().Names.Add(functionName);
+
+                        Scope functionScope = new([], "function");
+                        if (function is FunctionExpression &&  functionName is not null)
+                            functionScope.Names.Add(functionName);
+
+                        CollectParams(function, functionScope.Names);
+                        scopeStack.Push(functionScope);
+                        break;
+
+                    case BlockStatement blockStmt:
+                        scopeStack.Push(new([], "block"));
+                        break;
+
+                    case CatchClause catchClse:
+                        HashSet<string> set = [];
+
+                        CollectBindingIdentifiers(catchClse.Param, set);
+                        scopeStack.Push(new(set, "block"));
+                        break;
+
+                    case VariableDeclaration variableDecl:
+                        Scope currentScope = scopeStack.Peek();
+
+                        foreach (var declaration in variableDecl.Declarations)
+                            CollectBindingIdentifiers(declaration.Id, currentScope.Names);
+                        break;
+
+                    case ClassDeclaration classDecl:
+                        if (classDecl.Id is Identifier classId)
+                            scopeStack.Peek().Names.Add(classId.Name);
+                        break;
+
+                    case LabeledStatement labeledStmt:
+                        scopeStack.Peek().Names.Add(labeledStmt.Label.Name);
+                        break;
+
+                    case Identifier identifier:
+                        if (identifier.Name == rootIdentifierName)
+                            return AstWalker.CONTINUE;
+
+                        if (parent is Property prop && prop.Key == identifier && !prop.Computed)
+                            return AstWalker.CONTINUE;
+
+                        if (parent is MemberExpression memberExpr && memberExpr.Property == identifier && !memberExpr.Computed)
+                        {
+                            if (memberExpr.Object is ThisExpression)
+                                return AstWalker.CONTINUE;
+
+                            string? full = memberExpr.MemberToString(source);
+                            if (full is null)
+                                return AstWalker.CONTINUE;
+
+                            if (declaredVariables.TryGetValue(full, out VariableMetadata declaredVariable))
+                            {
+                                declaredVariable.Dependents.Add(identifierName);
+                                dependencies.Add(full);
+                            }
+                            else if (memberExpr.Object is Identifier objectId)
+                            {
+                                if ((
+                                        declaredVariables.TryGetValue(objectId.Name, out VariableMetadata? declaredBaseVariable) ||
+                                        objectId.Name == lifeParamName
+                                    ) &&
+                                    !IsInScope(objectId.Name) &&
+                                    !JsBuiltIns.Contains(objectId.Name)
+                                    )
+                                {
+                                    declaredBaseVariable?.Dependents.Add(identifierName);
+                                    dependencies.Add(full);
+
+                                    if (dependentsTracker.TryGetValue(full, out HashSet<string> existingTracker))
+                                        existingTracker.Add(identifierName);
+                                    else
+                                        dependentsTracker.Add(full, [ identifierName ]);
+                                }
+                            }
+                            return AstWalker.CONTINUE;
+                        }
+
+                        if (IsInScope(identifier.Name) || JsBuiltIns.Contains(identifier.Name))
+                            return AstWalker.CONTINUE;
+
+                        dependencies.Add(identifier.Name);
+
+                        if (declaredVariables.TryGetValue(identifierName, out VariableMetadata declaredVariableShit))
+                            declaredVariableShit.Dependents.Add(identifierName);
+                        else
+                        {
+                            if (dependentsTracker.TryGetValue(identifier.Name, out HashSet<string> existingTracker))
+                                existingTracker.Add(identifierName);
+                            else
+                                dependentsTracker.Add(identifier.Name, [ identifierName ]);
+                        }
+
+                        break;
+                }
+                return AstWalker.CONTINUE;
+            },
+
+            (currentNode, parent, ancestors) =>
+            {
+                switch (currentNode)
+                {
+                    case IFunction:
+                    case BlockStatement:
+                    case CatchClause:
+                        if (scopeStack.Count > 1)
+                            scopeStack.Pop();
+                        break;
+                }
+                return AstWalker.CONTINUE;
+            });
+
+        return dependencies;
+    }
+
+    bool AreDependenciesResolved(
+        HashSet<string> dependencies,
+        HashSet<string> seen)
+    {
+        if (dependencies.Count < 1)
+            return true;
+
+        foreach (string dependency in dependencies)
+        {
+            if (JsBuiltIns.Contains(dependency))
+                continue;
+
+            if (dependency == lifeParamName)
+                continue;
+
+            if (seen.Contains(dependency))
+                continue;
+
+            if (!declaredVariables.TryGetValue(dependency, out VariableMetadata? depMeta))
+                return false;
+
+            seen.Add(dependency);
+
+            if (!AreDependenciesResolved(depMeta.Dependents, seen))
+                return false;
+        }
+
+        return true;
+    }
+
+
+    bool TryMatch(
+        Node node,
+        VariableMetadata? metadata)
+    {
+        if (extractionStates.Length < 1)
+            return false;
+
+        bool isMatched = false;
+        Node? result = null;
+
+        foreach (ExtractionState state in extractionStates)
+        {
+            if (state.Node is null)
+            {
+                if (node is VariableDeclarator variableDeclarator && variableDeclarator.Init is null)
+                    continue;
+
+                result = state.Extractor.TryMatch(node);
+                if (result is null)
+                    continue;
+
+                state.Node = result;
+            }
+            else if (state.Node != node)
+            {
+                RefreshExtractionState(state);
+
+                if (ShouldStopTraversal())
+                    return true;
+
+                continue;
+            }
+
+            isMatched = true;
+
+            if (metadata is not null)
+            {
+                state.Metadata = metadata;
+                state.Dependencies = metadata.Dependencies;
+                state.Dependents = metadata.Dependents;
+                if (result is not null)
+                    state.MatchContext = node;
+            }
+
+            RefreshExtractionState(state);
+        }
+
+        if (!isMatched)
+            return false;
+
+        return ShouldStopTraversal();
+    }
+
+    bool ShouldStopTraversal()
+    {
+        if (extractionStates.Length < 1)
+            return false;
+
+        bool hasStoppingTarget = false;
+        foreach (ExtractionState state in extractionStates)
+        {
+            hasStoppingTarget = true;
+
+            if (state.Node is null || !state.IsReady)
+                return false;
+        }
+
+        return hasStoppingTarget;
+    }
+
+    void RefreshExtractionState(
+        ExtractionState state)
+    {
+        if (state.Node is null)
+        {
+            state.IsReady = false;
+            return;
+        }
+
+        if (state.Extractor.CollectDependencies == false)
+        {
+            state.IsReady = true;
+            return;
+        }
+
+        if (state.Metadata is null)
+        {
+            state.IsReady = false;
+            return;
+        }
+
+        state.IsReady = AreDependenciesResolved(state.Dependencies, []);
+    }
+}

--- a/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
@@ -1,0 +1,192 @@
+﻿using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal class JsExtractor(
+    JsAnalyzer analyzer,
+    bool isStrictMode) // aka disallowSideEffectInitializers
+{
+    readonly JsAnalyzer analyzer = analyzer;
+    readonly bool isStrictMode = isStrictMode;
+
+
+    bool AreSafeArgs(
+        IEnumerable<Expression?> args,
+        bool isStrictMode = true)
+    {
+        foreach (Node? arg in args)
+        {
+            if (arg is null)
+                return false;
+
+            if (arg is SpreadElement)
+                return false;
+
+            if (!IsSafeInitializer(arg, isStrictMode))
+                return false;
+        }
+
+        return true;
+    }
+
+    bool IsSafeInitializer(
+        Node? node,
+        bool isStrictMode = true)
+    {
+        if (node is null)
+            return true;
+
+        switch (node)
+        {
+            case TemplateLiteral templateLiteral:
+                return templateLiteral.Expressions.All(expr => IsSafeInitializer(expr, isStrictMode));
+
+            case Literal literal:
+                return
+                    literal.Value is string ||
+                    literal.Value is double ||
+                    literal.Value is bool ||
+                    literal.Value is null ||
+                    literal is RegExpLiteral;
+
+            case ArrayExpression arrayExpr:
+                return arrayExpr.Elements.All(element =>
+                {
+                    if (element is SpreadElement)
+                        return false;
+
+                    return IsSafeInitializer(element, isStrictMode);
+                });
+
+            case ObjectExpression objectExpr:
+                return objectExpr.Properties.All(prop =>
+                {
+                    if (prop is not Property property)
+                        return false;
+
+                    if (property.Computed ||
+                        property.Kind != PropertyKind.Init)
+                        return false;
+
+                    if (property.Value is null)
+                        return false;
+
+                    return property.Value is FunctionExpression ||
+                        property.Value is ArrowFunctionExpression ||
+                        property.Value is Literal;
+                });
+
+            case CallExpression callExpr:
+                if (callExpr.Callee is Identifier callExprCalleeId && JsAnalyzer.BuiltIns.Contains(callExprCalleeId.Name))
+                {
+                    return AreSafeArgs(callExpr.Arguments, isStrictMode);
+                }
+                else if (callExpr.Callee is MemberExpression callExprCalleeMemberExpr)
+                {
+                    if (!IsSafeInitializer(callExprCalleeMemberExpr.Object, isStrictMode))
+                        return false;
+
+                    if (isStrictMode)
+                    {
+                        string propertyName = callExprCalleeMemberExpr.Property is Identifier propertyId ? propertyId.Name : "";
+                        if (callExprCalleeMemberExpr.Computed || !JsAnalyzer.BuiltIns.Contains(propertyName))
+                            return false;
+                    }
+
+                    return AreSafeArgs(callExpr.Arguments, isStrictMode);
+                }
+
+                return false;
+
+            case NewExpression newExpr:
+                if (newExpr.Callee is Identifier newExprCalleeId &&
+                    (
+                        JsAnalyzer.BuiltIns.Contains(newExprCalleeId.Name) ||
+                        !isStrictMode
+                    ))
+                    return AreSafeArgs(newExpr.Arguments, isStrictMode);
+
+                return false;
+
+            case UnaryExpression unaryExpr:
+                return IsSafeInitializer(unaryExpr.Argument, isStrictMode);
+
+            case FunctionExpression:
+            case ArrowFunctionExpression:
+            case Identifier:
+                return true;
+
+            case MemberExpression memberExpr:
+                if (!isStrictMode)
+                {
+                    if (memberExpr.Computed && !IsSafeInitializer(memberExpr.Property, isStrictMode))
+                        return false;
+
+                    return IsSafeInitializer(memberExpr.Object, isStrictMode);
+                }
+
+                return false;
+
+            case BinaryExpression binaryExpr:
+                return IsSafeInitializer(binaryExpr.Left, isStrictMode) &&
+                    IsSafeInitializer(binaryExpr.Right, isStrictMode);
+
+            case ConditionalExpression conditionalExpr:
+                if (!isStrictMode)
+                    return IsSafeInitializer(conditionalExpr.Test, isStrictMode) &&
+                        IsSafeInitializer(conditionalExpr.Consequent, isStrictMode) &&
+                        IsSafeInitializer(conditionalExpr.Alternate, isStrictMode);
+
+                return false;
+
+            case SequenceExpression sequenceExpr:
+                if (!isStrictMode)
+                    return sequenceExpr.Expressions.All(expr => IsSafeInitializer(expr, isStrictMode));
+
+                return false;
+
+            case AssignmentExpression assignmentExpr:
+                if (assignmentExpr.Left is MemberExpression assigmentExprLeftMemberExpr && assigmentExprLeftMemberExpr.Computed)
+                {
+                    if (assigmentExprLeftMemberExpr.Object is Identifier identifier &&
+                        analyzer.DeclaredVariables.TryGetValue(identifier.Name, out VariableMetadata metadata) &&
+                        metadata.Node is VariableDeclarator variableDecl &&
+                        variableDecl.Init is not null)
+                        return IsSafeInitializer(assignmentExpr.Right, isStrictMode);
+                }
+                else if (assignmentExpr.Left is Identifier identifier)
+                {
+                    if (analyzer.DeclaredVariables.ContainsKey(identifier.Name))
+                        return IsSafeInitializer(assignmentExpr.Right, isStrictMode);
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    string GetInitializerFallback(
+        Expression? init) =>
+        init switch
+        {
+            ObjectExpression or
+            NewExpression or
+            MemberExpression or
+            LogicalExpression => "{}",
+
+            ArrayExpression => "[]",
+            _ => "undefined",
+        };
+
+
+    object RenderNode(
+        Node node,
+        bool isPreDeclared)
+    {
+        bool canDissalow = true;
+
+
+    }
+}

--- a/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
@@ -1,18 +1,40 @@
-﻿using Acornima.Ast;
+﻿using Acornima;
+using Acornima.Ast;
+using Newtonsoft.Json;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace YouTubeMusicAPI.Internal.JavaScript;
 
 internal class JsExtractor(
     JsAnalyzer analyzer,
-    bool isStrictMode) // aka disallowSideEffectInitializers
+    int maxDepth = int.MaxValue,
+    bool forceVarPredeclaration = false,
+    bool isStrictMode = true, // aka disallowSideEffectInitializers
+    string[]? skipEmitFor = null) // aka disallowSideEffectInitializers
 {
+    public class Result(
+        string output,
+        IReadOnlyList<string> exported,
+        IReadOnlyDictionary<string, object?> exportedRawValues)
+    {
+        public string Output { get; } = output;
+
+        public IReadOnlyList<string> Exported { get; } = exported;
+
+        public IReadOnlyDictionary<string, object?> ExportedRawValues { get; } = exportedRawValues;
+    }
+
+
     readonly JsAnalyzer analyzer = analyzer;
+    readonly int MaxDepth = maxDepth;
+    readonly bool forceVarPredeclaration = forceVarPredeclaration;
     readonly bool isStrictMode = isStrictMode;
+    readonly string[] skipEmitFor = skipEmitFor ?? [];
 
 
     bool AreSafeArgs(
-        IEnumerable<Expression?> args,
-        bool isStrictMode = true)
+        IEnumerable<Expression?> args)
     {
         foreach (Node? arg in args)
         {
@@ -22,7 +44,7 @@ internal class JsExtractor(
             if (arg is SpreadElement)
                 return false;
 
-            if (!IsSafeInitializer(arg, isStrictMode))
+            if (!IsSafeInitializer(arg))
                 return false;
         }
 
@@ -30,8 +52,7 @@ internal class JsExtractor(
     }
 
     bool IsSafeInitializer(
-        Node? node,
-        bool isStrictMode = true)
+        Node? node)
     {
         if (node is null)
             return true;
@@ -39,7 +60,7 @@ internal class JsExtractor(
         switch (node)
         {
             case TemplateLiteral templateLiteral:
-                return templateLiteral.Expressions.All(expr => IsSafeInitializer(expr, isStrictMode));
+                return templateLiteral.Expressions.All(expr => IsSafeInitializer(expr));
 
             case Literal literal:
                 return
@@ -55,7 +76,7 @@ internal class JsExtractor(
                     if (element is SpreadElement)
                         return false;
 
-                    return IsSafeInitializer(element, isStrictMode);
+                    return IsSafeInitializer(element);
                 });
 
             case ObjectExpression objectExpr:
@@ -79,11 +100,11 @@ internal class JsExtractor(
             case CallExpression callExpr:
                 if (callExpr.Callee is Identifier callExprCalleeId && JsAnalyzer.BuiltIns.Contains(callExprCalleeId.Name))
                 {
-                    return AreSafeArgs(callExpr.Arguments, isStrictMode);
+                    return AreSafeArgs(callExpr.Arguments);
                 }
                 else if (callExpr.Callee is MemberExpression callExprCalleeMemberExpr)
                 {
-                    if (!IsSafeInitializer(callExprCalleeMemberExpr.Object, isStrictMode))
+                    if (!IsSafeInitializer(callExprCalleeMemberExpr.Object))
                         return false;
 
                     if (isStrictMode)
@@ -93,7 +114,7 @@ internal class JsExtractor(
                             return false;
                     }
 
-                    return AreSafeArgs(callExpr.Arguments, isStrictMode);
+                    return AreSafeArgs(callExpr.Arguments);
                 }
 
                 return false;
@@ -104,12 +125,12 @@ internal class JsExtractor(
                         JsAnalyzer.BuiltIns.Contains(newExprCalleeId.Name) ||
                         !isStrictMode
                     ))
-                    return AreSafeArgs(newExpr.Arguments, isStrictMode);
+                    return AreSafeArgs(newExpr.Arguments);
 
                 return false;
 
             case UnaryExpression unaryExpr:
-                return IsSafeInitializer(unaryExpr.Argument, isStrictMode);
+                return IsSafeInitializer(unaryExpr.Argument);
 
             case FunctionExpression:
             case ArrowFunctionExpression:
@@ -119,29 +140,29 @@ internal class JsExtractor(
             case MemberExpression memberExpr:
                 if (!isStrictMode)
                 {
-                    if (memberExpr.Computed && !IsSafeInitializer(memberExpr.Property, isStrictMode))
+                    if (memberExpr.Computed && !IsSafeInitializer(memberExpr.Property))
                         return false;
 
-                    return IsSafeInitializer(memberExpr.Object, isStrictMode);
+                    return IsSafeInitializer(memberExpr.Object);
                 }
 
                 return false;
 
             case BinaryExpression binaryExpr:
-                return IsSafeInitializer(binaryExpr.Left, isStrictMode) &&
-                    IsSafeInitializer(binaryExpr.Right, isStrictMode);
+                return IsSafeInitializer(binaryExpr.Left) &&
+                    IsSafeInitializer(binaryExpr.Right);
 
             case ConditionalExpression conditionalExpr:
                 if (!isStrictMode)
-                    return IsSafeInitializer(conditionalExpr.Test, isStrictMode) &&
-                        IsSafeInitializer(conditionalExpr.Consequent, isStrictMode) &&
-                        IsSafeInitializer(conditionalExpr.Alternate, isStrictMode);
+                    return IsSafeInitializer(conditionalExpr.Test) &&
+                        IsSafeInitializer(conditionalExpr.Consequent) &&
+                        IsSafeInitializer(conditionalExpr.Alternate);
 
                 return false;
 
             case SequenceExpression sequenceExpr:
                 if (!isStrictMode)
-                    return sequenceExpr.Expressions.All(expr => IsSafeInitializer(expr, isStrictMode));
+                    return sequenceExpr.Expressions.All(expr => IsSafeInitializer(expr));
 
                 return false;
 
@@ -152,12 +173,12 @@ internal class JsExtractor(
                         analyzer.DeclaredVariables.TryGetValue(identifier.Name, out VariableMetadata metadata) &&
                         metadata.Node is VariableDeclarator variableDecl &&
                         variableDecl.Init is not null)
-                        return IsSafeInitializer(assignmentExpr.Right, isStrictMode);
+                        return IsSafeInitializer(assignmentExpr.Right);
                 }
                 else if (assignmentExpr.Left is Identifier identifier)
                 {
                     if (analyzer.DeclaredVariables.ContainsKey(identifier.Name))
-                        return IsSafeInitializer(assignmentExpr.Right, isStrictMode);
+                        return IsSafeInitializer(assignmentExpr.Right);
                 }
 
                 return false;
@@ -181,12 +202,209 @@ internal class JsExtractor(
         };
 
 
-    object RenderNode(
-        Node node,
+    string RenderNode(
+        Node? node,
         bool isPreDeclared)
     {
-        bool canDissalow = true;
+        AssignmentExpression? assignmentTarget = node is AssignmentExpression assignmentExpr
+            ? assignmentExpr
+            : node is ExpressionStatement expressionStmt && expressionStmt.Expression is AssignmentExpression innerAssignmentExpr
+                ? innerAssignmentExpr
+                : null;
+
+        Expression? init = assignmentTarget is not null && assignmentTarget.Operator == Operator.Assignment
+            ? assignmentTarget.Right
+            : node is VariableDeclarator innerVariableDecl
+                ? innerVariableDecl.Init
+                : null;
+        bool forceRemove = init is not null && !IsSafeInitializer(init);
+        string initializerFallback = GetInitializerFallback(init);
+
+        string initSource = initializerFallback;
+
+        if (!forceRemove && init is not null)
+        {
+            if (isPreDeclared || init is not Identifier identifier || analyzer.DeclaredVariables.ContainsKey(identifier.Name))
+            {
+                if (assignmentTarget?.Left is MemberExpression memberExpr && init is not null)
+                {
+                    if (memberExpr.Object is Identifier &&
+                        init is not FunctionExpression &&
+                        init is not ArrowFunctionExpression &&
+                        init is not LogicalExpression)
+                        return $"   // Skipped {memberExpr.MemberToString(analyzer.Source)} assignment.";
+                }
+
+                initSource = init?.ExtractNodeSource(analyzer.Source) is string s
+                    ? Regex.Replace(s, @";\s*$", "")
+                    : "kk"; // wtf is kk ??
+            }
+        }
+
+        if (!forceRemove && init is SequenceExpression && initSource.StartsWith("("))
+            initSource = $"({initSource})";
+
+        string idName = node is VariableDeclarator variableDecl && variableDecl.Id is Identifier id
+            ? id.Name
+            : assignmentTarget?.Left is Identifier leftId
+                ? leftId.Name
+                : assignmentTarget?.Left is Identifier assigmentTargetLeftIdentifier
+                    ? assigmentTargetLeftIdentifier.Name
+                    : assignmentTarget is AssignmentExpression actualHolyShitAssignmentExpr
+                        ? (actualHolyShitAssignmentExpr.Left is MemberExpression imGogingCrazyMemberExpr
+                            ? imGogingCrazyMemberExpr.MemberToString(analyzer.Source) ?? "unknown"
+                            : "unknown")
+                        : "unknown";
+
+        string assignmentExpression = $"{idName} = {initSource};";
+
+        if (node is VariableDeclarator thirdsTimesTheCharmVariableDecl && thirdsTimesTheCharmVariableDecl.Init is not null && !isPreDeclared)
+            return $"   var {assignmentExpression}";
+
+        return $"   {assignmentExpression}";
+    }
 
 
+    public Result BuildScript()
+    {
+        IEnumerable<ExtractionState> extractions = analyzer.ExtractionStates;
+        HashSet<string> seen = [.. extractions.Select(state => state.Metadata?.Name ?? "")];
+
+        List<string> snippsets = [];
+        HashSet<string> predeclaredVarSet = [];
+        Dictionary<string, Node> exported = [];
+        Dictionary<string, object?> exportedRawValues = [];
+
+        void RegisterPredeclaredVar(
+            string? name)
+        {
+            if (name is null || name.Contains('.'))
+                return;
+
+            predeclaredVarSet.Add(name);
+        }
+
+        void Visit(
+            VariableMetadata? metadata,
+            int depth = 0)
+        {
+            if (metadata is null || depth > MaxDepth)
+                return;
+
+            foreach (string dependency in metadata.Dependencies)
+            {
+                if (seen.Contains(dependency))
+                    continue;
+
+                seen.Add(dependency);
+
+                if (!analyzer.DeclaredVariables.TryGetValue(dependency, out VariableMetadata? dependencyMetadata))
+                    continue;
+
+                bool shouldPredeclare = forceVarPredeclaration || dependencyMetadata.IsPredeclared;
+                if (shouldPredeclare)
+                    RegisterPredeclaredVar(dependencyMetadata.Name);
+
+                if (!dependency.Contains('.'))
+                    Visit(dependencyMetadata, depth + 1);
+
+                snippsets.Add(RenderNode(dependencyMetadata.Node, shouldPredeclare));
+            }
+        }
+
+        foreach (ExtractionState extraction in extractions)
+        {
+            string name = extraction.Extractor.Name;
+            bool shouldSkip = skipEmitFor.Contains(name);
+
+            if (extraction.Metadata is not null)
+            {
+                if (!shouldSkip)
+                    snippsets.Add($"    //#region --- start [{name}] ---");
+
+                bool shouldPredeclare = (forceVarPredeclaration || extraction.Metadata.IsPredeclared) && !shouldSkip;
+                if (shouldPredeclare)
+                    RegisterPredeclaredVar(extraction.Metadata.Name);
+
+                if (extraction.Extractor.CollectDependencies && !shouldSkip)
+                    Visit(extraction.Metadata);
+
+                if (extraction.MatchContext is not null)
+                {
+                    exported.Add(name, extraction.MatchContext);
+
+                    string? rawValue = null;
+
+                    if (extraction.MatchContext is Property property)
+                        rawValue = property.Value.ExtractNodeSource(analyzer.Source);
+                    else if (extraction.MatchContext is Identifier identifier)
+                        rawValue = identifier.Name;
+                    else
+                        rawValue = extraction.MatchContext.ExtractNodeSource(analyzer.Source);
+
+                    exportedRawValues[name] = rawValue;
+                }
+
+                if (!shouldSkip)
+                    snippsets.Add($"    //#endregion --- start [{name}] ---\n");
+            }
+        }
+
+        StringBuilder output = new();
+
+        // safety I GUESS
+        output.AppendLine("const window = Object.assign({}, globalThis);");
+        output.AppendLine("const document = {};");
+        output.AppendLine("const self = window;\n");
+
+        output.AppendLine($"const exportedVars = (function({analyzer.LifeParamName}) {{");
+        if (predeclaredVarSet.Count > 0)
+            output.AppendLine($"    var {string.Join(", ", predeclaredVarSet)};\n");
+
+        output.AppendLine(string.Join("\n", snippsets));
+
+        List<string> exportedVars = [];
+        foreach (KeyValuePair<string, Node> export in exported)
+        {
+            Node? currentFunctionNode = null;
+
+            if (export.Value is Identifier identifier)
+            {
+                if (analyzer.DeclaredVariables.TryGetValue(identifier.Name, out VariableMetadata? metadata) &&
+                    metadata.Node is VariableDeclarator variableDecl &&
+                    variableDecl.Init is FunctionExpression)
+                    currentFunctionNode = metadata.Node;
+            }
+            else if (export.Value is CallExpression)
+            {
+                currentFunctionNode = export.Value;
+            }
+
+            string? wrapper = currentFunctionNode?.CreateWrapperFunction(export.Key, analyzer);
+            if (wrapper is not null)
+            {
+                output.AppendLine($"{wrapper}\n");
+                exportedVars.Add(export.Key);
+            }
+        }
+
+        // export raw values: ALWAYS TRUE WUHWUHWUHWUHW
+        string rawJson = JsonConvert.SerializeObject(exportedRawValues, Formatting.Indented);
+        string[] rawJsonLines = rawJson.Split('\n');
+
+        string formattedRawJson = rawJsonLines.Length > 0
+            ? $"{rawJsonLines[0]}\n{string.Join("\n", rawJsonLines.Skip(1).Select(line => $"    {line}"))}"
+            : rawJson;
+
+        output.AppendLine($"    const rawValues = {formattedRawJson};\n");
+        exportedVars.Add("rawValues");
+
+        output.AppendLine($"    return {{ {string.Join(", ", exportedVars)} }};");
+        output.AppendLine("})({});\n");
+
+        return new(
+            output.ToString(),
+            exportedVars,
+            exportedRawValues);
     }
 }

--- a/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsExtractor.cs
@@ -167,7 +167,7 @@ internal class JsExtractor(
                 return false;
 
             case AssignmentExpression assignmentExpr:
-                if (assignmentExpr.Left is MemberExpression assigmentExprLeftMemberExpr && assigmentExprLeftMemberExpr.Computed)
+                if (assignmentExpr.Left is MemberExpression assigmentExprLeftMemberExpr && !assigmentExprLeftMemberExpr.Computed)
                 {
                     if (assigmentExprLeftMemberExpr.Object is Identifier identifier &&
                         analyzer.DeclaredVariables.TryGetValue(identifier.Name, out VariableMetadata metadata) &&
@@ -241,7 +241,7 @@ internal class JsExtractor(
             }
         }
 
-        if (!forceRemove && init is SequenceExpression && initSource.StartsWith("("))
+        if (!forceRemove && init is SequenceExpression && !initSource.StartsWith("("))
             initSource = $"({initSource})";
 
         string idName = node is VariableDeclarator variableDecl && variableDecl.Id is Identifier id
@@ -346,7 +346,7 @@ internal class JsExtractor(
                 }
 
                 if (!shouldSkip)
-                    snippsets.Add($"    //#endregion --- start [{name}] ---\n");
+                    snippsets.Add($"    //#endregion --- end [{name}] ---\n");
             }
         }
 

--- a/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
@@ -9,7 +9,7 @@ internal static class JsMatchers
         Node node);
 
 
-    public static Node? Sig(
+    public static Node? Signature(
         Node node)
     {
         if (node is not VariableDeclarator variableDecl ||
@@ -41,7 +41,7 @@ internal static class JsMatchers
         return null;
     }
 
-    public static Node? NSig(
+    public static Node? NSignature(
         Node node)
     {
         if (node is not VariableDeclarator variableDecr ||
@@ -52,7 +52,7 @@ internal static class JsMatchers
         return identifier;
     }
 
-    public static Node? SigTimestamp(
+    public static Node? SignatureTimestamp(
         Node node)
     {
         if (node is not ExpressionStatement expressionStmt ||

--- a/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
@@ -9,7 +9,7 @@ internal static class JsMatchers
         Node node);
 
 
-    public static Node? TryMatchSig(
+    public static Node? Sig(
         Node node)
     {
         if (node is not VariableDeclarator variableDecl ||
@@ -41,7 +41,7 @@ internal static class JsMatchers
         return null;
     }
 
-    public static Node? TryMatchNSig(
+    public static Node? NSig(
         Node node)
     {
         if (node is not VariableDeclarator variableDecr ||
@@ -52,7 +52,7 @@ internal static class JsMatchers
         return identifier;
     }
 
-    public static Node? TryMatchSigTimestamp(
+    public static Node? SigTimestamp(
         Node node)
     {
         if (node is not ExpressionStatement expressionStmt ||

--- a/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
@@ -1,0 +1,86 @@
+﻿using Acornima;
+using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal static class JsMatchers
+{
+    public delegate Node? Delegate(
+        Node node);
+
+
+    public static Node? TryMatchSig(
+        Node node)
+    {
+        if (node is not VariableDeclarator variableDecl ||
+            variableDecl.Init is not FunctionExpression functionExpr ||
+            functionExpr.Body is not BlockStatement blockStmt)
+            return null;
+
+        foreach (Statement statement in blockStmt.Body)
+        {
+            if (statement is not ExpressionStatement expressionStmt ||
+                expressionStmt.Expression is not LogicalExpression logicalExpr ||
+                logicalExpr.Operator != Operator.LogicalAnd ||
+                logicalExpr.Left is not Identifier ||
+                logicalExpr.Right is not SequenceExpression sequenceExpr ||
+                sequenceExpr.Expressions.FirstOrDefault() is not AssignmentExpression assignmentExpr ||
+                assignmentExpr.Operator != Operator.Assignment ||
+                assignmentExpr.Left is not Identifier ||
+                assignmentExpr.Right is not CallExpression callExpr ||
+                callExpr.Callee is not Identifier ||
+                callExpr.Arguments.FirstOrDefault(exp => exp is CallExpression) is not CallExpression innerCallExpr ||
+                innerCallExpr.Callee is not Identifier identifier ||
+                identifier.Name != "decodeURIComponent" ||
+                innerCallExpr.Arguments.FirstOrDefault() is not Identifier)
+                continue;
+
+            return callExpr;
+        }
+
+        return null;
+    }
+
+    public static Node? TryMatchNSig(
+        Node node)
+    {
+        if (node is not VariableDeclarator variableDecr ||
+            variableDecr.Init is not ArrayExpression arrayExpr ||
+            arrayExpr.Elements.FirstOrDefault() is not Identifier identifier)
+            return null;
+
+        return identifier;
+    }
+
+    public static Node? TryMatchSigTimestamp(
+        Node node)
+    {
+        if (node is not ExpressionStatement expressionStmt ||
+            expressionStmt.Expression is not AssignmentExpression assignmentExpr ||
+            assignmentExpr.Right is not FunctionExpression functionExpr ||
+            functionExpr.Body is not BlockStatement blockStmt)
+            return null;
+
+        foreach (Statement statement in blockStmt.Body)
+        {
+            if (statement is not ExpressionStatement innerExpressionStmt ||
+                innerExpressionStmt.Expression is not AssignmentExpression innerAsiignmentExpr ||
+                innerAsiignmentExpr.Right is not ObjectExpression objectExpr)
+                continue;
+
+            foreach (Node objectProp in objectExpr.Properties)
+            {
+                if (objectProp is not Property prop ||
+                    prop.Key is not Identifier identifier ||
+                    identifier.Name != "signatureTimestamp" ||
+                    prop.Value is not Literal literal ||
+                    literal.Value is null)
+                    continue;
+
+                return literal;
+            }
+        }
+
+        return null;
+    }
+}

--- a/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/JsMatchers.cs
@@ -55,9 +55,8 @@ internal static class JsMatchers
     public static Node? SignatureTimestamp(
         Node node)
     {
-        if (node is not ExpressionStatement expressionStmt ||
-            expressionStmt.Expression is not AssignmentExpression assignmentExpr ||
-            assignmentExpr.Right is not FunctionExpression functionExpr ||
+        if (node is not VariableDeclarator variableDeclarator ||
+            variableDeclarator.Init is not FunctionExpression functionExpr ||
             functionExpr.Body is not BlockStatement blockStmt)
             return null;
 

--- a/YouTubeMusicAPI/Internal/JavaScript/VariableMetadata.cs
+++ b/YouTubeMusicAPI/Internal/JavaScript/VariableMetadata.cs
@@ -1,0 +1,21 @@
+﻿using Acornima.Ast;
+
+namespace YouTubeMusicAPI.Internal.JavaScript;
+
+internal class VariableMetadata(
+    string name,
+    Node? node,
+    HashSet<string> dependencies,
+    HashSet<string> dependents,
+    bool isPredeclared)
+{
+    public string Name { get; set; } = name;
+
+    public Node? Node { get; set; } = node;
+
+    public HashSet<string> Dependencies { get; set; } = dependencies;
+
+    public HashSet<string> Dependents { get; set; } = dependents;
+
+    public bool IsPredeclared { get; set; } = isPredeclared;
+}

--- a/YouTubeMusicAPI/Internal/Parsers/InfoParser.cs
+++ b/YouTubeMusicAPI/Internal/Parsers/InfoParser.cs
@@ -1,5 +1,5 @@
-﻿using System.Globalization;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
+using System.Globalization;
 using YouTubeMusicAPI.Models.Info;
 using YouTubeMusicAPI.Pagination;
 
@@ -133,7 +133,7 @@ internal static class InfoParser
 
         List<CommunityPlaylistSong> result = [];
         string? nextContinuationToken = null;
-        
+
         foreach (JToken content in contentsToken)
         {
             if (content.SelectObjectOptional<string>("continuationItemRenderer.continuationEndpoint.continuationCommand.token") is string continuationToken)

--- a/YouTubeMusicAPI/Internal/Parsers/InfoParser.cs
+++ b/YouTubeMusicAPI/Internal/Parsers/InfoParser.cs
@@ -38,7 +38,7 @@ internal static class InfoParser
             id: playerJsonToken.SelectObject<string>("videoDetails.videoId"),
             browseId: nextTabContainer.SelectObject<string>("[2].tabRenderer.endpoint.browseEndpoint.browseId"),
             description: playerJsonToken.SelectObject<string>("microformat.microformatDataRenderer.description"),
-            artists: nextItem.SelectArtists("longBylineText.runs", 0, albumIndex),
+            artists: nextItem.SelectArtists("longBylineText.runs", 0, runs.Length - albumIndex),
             album: albumId is not null ? new(nextItem.SelectObject<string>($"longBylineText.runs[{albumIndex}].text"), albumId) : null,
             duration: TimeSpan.FromSeconds(playerJsonToken.SelectObject<int>("videoDetails.lengthSeconds")),
             radio: isLive ? null : nextItem.SelectRadioOptional(),

--- a/YouTubeMusicAPI/Internal/Parsers/SearchParser.cs
+++ b/YouTubeMusicAPI/Internal/Parsers/SearchParser.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
-using YouTubeMusicAPI.Pagination;
 using YouTubeMusicAPI.Models;
 using YouTubeMusicAPI.Models.Search;
+using YouTubeMusicAPI.Pagination;
 
 namespace YouTubeMusicAPI.Internal.Parsers;
 

--- a/YouTubeMusicAPI/Internal/Payload.cs
+++ b/YouTubeMusicAPI/Internal/Payload.cs
@@ -28,7 +28,7 @@ public static class Payload
                 client = new
                 {
                     clientName = "WEB_REMIX",
-                    clientVersion = "1.20211213.00.00",
+                    clientVersion = "1.20251022.00.01",
                     browserName = "Chrome",
                     browserVersion = "130.0.0.0",
                     osName = "Windows",
@@ -59,7 +59,7 @@ public static class Payload
 
         return payload;
     }
-    
+
     /// <summary>
     /// Creates a new payload which mimics a YouTube mobile client
     /// </summary>
@@ -81,13 +81,13 @@ public static class Payload
                 client = new
                 {
                     clientName = "iOS",
-                    clientVersion = "19.45.4",
+                    clientVersion = "20.11.6",
                     deviceMake = "Apple",
                     deviceModel = "iPhone16,2",
                     osName = "IOS",
                     platform = "MOBILE",
                     osVersion = "18.1.0.22B83",
-                    userAgent = "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X; US)",
+                    userAgent = "com.google.ios.youtube/20.11.6 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X; US)",
                     timeZone = "UTC",
                     utcOffsetMinutes = 0,
                     hl = "en",
@@ -106,6 +106,4 @@ public static class Payload
 
         return payload;
     }
-
-    
 }

--- a/YouTubeMusicAPI/Internal/Player.cs
+++ b/YouTubeMusicAPI/Internal/Player.cs
@@ -1,11 +1,7 @@
-﻿using Acornima;
-using Acornima.Ast;
-using Jint;
+﻿using Jint;
 using System.Collections.Specialized;
 using System.Web;
-using System.Xml.Linq;
 using YouTubeMusicAPI.Internal.JavaScript;
-using static YouTubeMusicAPI.Internal.Player;
 
 namespace YouTubeMusicAPI.Internal;
 
@@ -14,6 +10,10 @@ internal class Player(
     int signatureTimestamp,
     string? poToken)
 {
+    readonly Engine jsEngine = new Engine().Execute(javasScript.Output);
+
+
+
     /// <summary>
     /// The JavaScript extraction result.
     /// </summary>
@@ -46,7 +46,7 @@ internal class Player(
         //string url = "https://www.youtube.com" + "/iframe_api";
         //string js = await requestHelper.GetAndValidateAsync(url, null, cancellationToken);
 
-        //string playerId = "bcd893b3";//js.GetStringBetween(@"player\/", @"\/") ?? throw new Exception("Failed to get player id");
+        //string playerId = "6e4dbefe";//js.GetStringBetween(@"player\/", @"\/") ?? throw new Exception("Failed to get player id");
         //string playerUrl = "https://www.youtube.com" + $"/s/player/{playerId}/player_ias.vflset/en_US/base.js";
 
         //File.WriteAllText("C:\\Users\\Kevin\\Desktop\\player.js", await requestHelper.GetAndValidateAsync(playerUrl, null, cancellationToken));
@@ -106,18 +106,14 @@ internal class Player(
             throw new Exception("Signature cipher does not contain s parameter.");
 
         // Signatures
-        Engine jsEngine = new Engine()
-            .SetValue("sig", sig)
-            .SetValue("nsig", nsig);
-
         if (sig is not null)
         {
-            string decipheredSig = jsEngine.Evaluate("").AsString();
+            string decipheredSig = jsEngine.Evaluate($"exportedVars.sigFunction('{sig}')").AsString();
             urlQuery[sp] = decipheredSig;
         }
         if (nsig is not null)
         {
-            string decipheredNSig = jsEngine.Evaluate("").AsString();
+            string decipheredNSig = jsEngine.Evaluate($"exportedVars.nSigFunction('{nsig}')").AsString();
             urlQuery["n"] = decipheredNSig;
         }
 

--- a/YouTubeMusicAPI/Internal/Player.cs
+++ b/YouTubeMusicAPI/Internal/Player.cs
@@ -26,129 +26,13 @@ internal class Player(
     }
 
 
-
-    static bool TryParseSignature(
-        Node node,
-        string playerJs,
-        out string? result)
-    {
-        if (node is not AssignmentExpression expression ||
-            expression.Right is not FunctionExpression functionExpr ||
-            functionExpr.Body is not BlockStatement block)
-        {
-            result = null;
-            return false;
-        }
-
-        foreach (Statement statement in block.Body)
-        {
-            if (statement is not ExpressionStatement exprStatement ||
-                exprStatement.Expression is not LogicalExpression logicalExpr ||
-                logicalExpr.Operator != Operator.LogicalAnd ||
-                logicalExpr.Left is not Identifier ||
-                logicalExpr.Right is not SequenceExpression sequenceExpr ||
-                sequenceExpr.Expressions.FirstOrDefault() is not AssignmentExpression assignmentExpr ||
-                assignmentExpr.Operator != Operator.Assignment ||
-                assignmentExpr.Left is not Identifier ||
-                assignmentExpr.Right is not CallExpression callExpr ||
-                callExpr.Callee is not Identifier ||
-                callExpr.Arguments.FirstOrDefault(exp => exp is CallExpression) is not CallExpression innerCallExpr ||
-                innerCallExpr.Callee is not Identifier identifier ||
-                identifier.Name != "decodeURIComponent" ||
-                innerCallExpr.Arguments.FirstOrDefault() is not Identifier)
-                continue;
-
-            result = callExpr.GetFunctionCode(playerJs);
-            return true;
-        }
-
-        result = null;
-        return false;
-    }
-
-    static bool TryParseNSignature(
-        Node node,
-        string playerJs,
-        out string? result)
-    {
-        if (node is not VariableDeclaration declaration)
-        {
-            result = null;
-            return false;
-        }
-
-        if (declaration.Declarations.Count != 1 ||
-            declaration.Declarations[0].Init is not ArrayExpression arrayExpr ||
-            arrayExpr.Elements.Count != 1 ||
-            arrayExpr.Elements[0] is not Identifier identifier)
-        {
-            result = null;
-            return false;
-        }
-
-        result = identifier.Name;
-        return true;
-
-    }
-
-    static bool TryParseSigTimestamp(
-        Node node,
-        string playerJs,
-        out int? result)
-    {
-        //if (node is not AssignmentExpression expression ||
-        //    expression.Right is not FunctionExpression functionExpr ||
-        //    functionExpr.Body is not BlockStatement block)
-        //{
-        //    result = null;
-        //    return false;
-        //}
-
-
-        //string code = block.GetFunctionCode(playerJs);
-        //if (code.Contains("signatureTimestamp:20374"))
-        //{
-
-        //}
-
-        if (node is not VariableDeclaration declaration)
-        {
-            result = null;
-            return false;
-        }
-
-        foreach (VariableDeclarator variable in declaration.Declarations)
-        {
-            if (variable.Init is not ObjectExpression objExpr)
-                continue;
-
-            foreach (Node objProp in objExpr.Properties)
-            {
-                if (objProp is not Property prop ||
-                    prop.Key is not Identifier identifier ||
-                    identifier.Name != "signatureTimestamp" ||
-                    prop.Value is not Literal literal ||
-                    literal.Value is null)
-                    continue;
-
-                result = Convert.ToInt32(literal.Value);
-                return true;
-            }
-
-        }
-
-        result = null;
-        return false;
-    }
-
-
     static JsAlgorithms ExtractJsAlgorithms(
         string playerJs)
     {
-        JsExtractor ex = new(playerJs, [
-            new("sigFunction", JsMatchers.TryParseSig, true),
-            new("nSigFunction", JsMatchers.TryParseNSig, true),
-            new("sigTimestampVar", JsMatchers.TryParseSigTimestamp, false)
+        JsAnalyzer ex = new(playerJs, [
+            new("sigFunction", JsMatchers.Sig, true),
+            new("nSigFunction", JsMatchers.NSig, true),
+            new("sigTimestampVar", JsMatchers.SigTimestamp, false)
             ]);
         return null;
 
@@ -159,14 +43,14 @@ internal class Player(
         int? sigTimestamp = null;
         foreach (Node node in ast.DescendantNodes())
         {
-            if (TryParseSignature(node, playerJs, out string? signatureResult))
-                signature = signatureResult;
+            //if (TryParseSignature(node, playerJs, out string? signatureResult))
+            //    signature = signatureResult;
 
-            else if (TryParseNSignature(node, playerJs, out string? nSignatureResult))
-                nSignature = nSignatureResult;
+            //else if (TryParseNSignature(node, playerJs, out string? nSignatureResult))
+            //    nSignature = nSignatureResult;
 
-            else if (TryParseSigTimestamp(node, playerJs, out int? sigTimestampResult))
-                sigTimestamp = sigTimestampResult;
+            //else if (TryParseSigTimestamp(node, playerJs, out int? sigTimestampResult))
+            //    sigTimestamp = sigTimestampResult;
         }
 
         if (signature is null)

--- a/YouTubeMusicAPI/Internal/Player.cs
+++ b/YouTubeMusicAPI/Internal/Player.cs
@@ -4,6 +4,7 @@ using Jint;
 using System.Collections.Specialized;
 using System.Web;
 using System.Xml.Linq;
+using YouTubeMusicAPI.Internal.JavaScript;
 using static YouTubeMusicAPI.Internal.Player;
 
 namespace YouTubeMusicAPI.Internal;
@@ -144,6 +145,13 @@ internal class Player(
     static JsAlgorithms ExtractJsAlgorithms(
         string playerJs)
     {
+        JsExtractor ex = new(playerJs, [
+            new("sigFunction", JsMatchers.TryParseSig, true),
+            new("nSigFunction", JsMatchers.TryParseNSig, true),
+            new("sigTimestampVar", JsMatchers.TryParseSigTimestamp, false)
+            ]);
+        return null;
+
         Script ast = new Parser().ParseScript(playerJs);
 
         string? signature = null;

--- a/YouTubeMusicAPI/Internal/Player.cs
+++ b/YouTubeMusicAPI/Internal/Player.cs
@@ -35,18 +35,23 @@ internal class Player(
     /// </summary>
     /// <param name="requestHelper">The HTTP request helper</param>
     /// <param name="poToken">The Proof of Origin Token (required for SABR Requests)</param>
+    /// <param name="playerId">Optional player id; if empty, derive the most recent player id from the iframe API</param>
     /// <param name="cancellationToken">The token to cancel this action</param>
     /// <returns>The player</returns>
     public static async Task<Player> CreateAsync(
         RequestHelper requestHelper,
         string? poToken,
+        string? playerId = null,
         CancellationToken cancellationToken = default)
     {
-        string url = "https://www.youtube.com" + "/iframe_api";
-        string js = await requestHelper.GetAndValidateAsync(url, null, cancellationToken);
+        if (string.IsNullOrEmpty(playerId))
+        {
+            string url = "https://www.youtube.com/iframe_api";
+            string js = await requestHelper.GetAndValidateAsync(url, null, cancellationToken);
 
-        string playerId = js.GetStringBetween(@"player\/", @"\/") ?? throw new Exception("Failed to get player id");
-        string playerUrl = "https://www.youtube.com" + $"/s/player/{playerId}/player_ias.vflset/en_US/base.js";
+            playerId = js.GetStringBetween(@"player\/", @"\/") ?? throw new Exception("Failed to get player id");
+        }
+        string playerUrl = $"https://www.youtube.com/s/player/{playerId}/player_ias.vflset/en_US/base.js";
 
         string playerJs = await requestHelper.GetAndValidateAsync(playerUrl, null, cancellationToken);
 

--- a/YouTubeMusicAPI/Internal/RequestHelper.cs
+++ b/YouTubeMusicAPI/Internal/RequestHelper.cs
@@ -73,7 +73,7 @@ internal class RequestHelper
         authentication.Prepare(request);
 
         // Send HTTP request
-        logger?.LogInformation($"[RequestHelper-GetAsync] Sending HTTP reuqest. GET: {url}.");
+        logger?.LogDebug($"[RequestHelper-GetAsync] Sending HTTP reuqest. GET: {url}.");
         return client.SendAsync(request, cancellationToken);
     }
 
@@ -96,7 +96,7 @@ internal class RequestHelper
         HttpResponseMessage httpResponse = await GetAsync(uri, parameters, cancellationToken).ConfigureAwait(false);
 
         // Parse HTTP response data
-        logger?.LogInformation($"[RequestHelper-GetAndValidateAsync] Parsing HTTP response.");
+        logger?.LogDebug($"[RequestHelper-GetAndValidateAsync] Parsing HTTP response.");
         string httpResponseData = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         // Check for exception
@@ -140,7 +140,7 @@ internal class RequestHelper
         authentication.Prepare(request);
 
         // Send HTTP request
-        logger?.LogInformation($"[RequestHelper-PostBodyAsync] Sending HTTP reuqest. POST: {url}.");
+        logger?.LogDebug($"[RequestHelper-PostBodyAsync] Sending HTTP reuqest. POST: {url}.");
         return client.SendAsync(request, cancellationToken);
     }
 
@@ -166,7 +166,7 @@ internal class RequestHelper
         HttpResponseMessage httpResponse = await PostAsync(uri, body, parameters, cancellationToken).ConfigureAwait(false);
 
         // Parse HTTP response data
-        logger?.LogInformation($"[RequestHelper-PostBodyAndValidateAsync] Parsing HTTP response.");
+        logger?.LogDebug($"[RequestHelper-PostBodyAndValidateAsync] Parsing HTTP response.");
         string httpResponseData = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         // Check for exception

--- a/YouTubeMusicAPI/Internal/Selectors.cs
+++ b/YouTubeMusicAPI/Internal/Selectors.cs
@@ -129,7 +129,7 @@ internal static class Selectors
         new(
             value.SelectObject<string>(playlistIdPath),
             videoIdPath is null ? null : value.SelectObjectOptional<string>(videoIdPath));
-    
+
     /// <summary>
     /// Selects and casts an optional radio from a json token
     /// </summary>

--- a/YouTubeMusicAPI/Models/PlaybackTracking.cs
+++ b/YouTubeMusicAPI/Models/PlaybackTracking.cs
@@ -7,7 +7,7 @@ public class PlaybackTracking
 {
     const string CpnCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 
-    readonly static Random CpnRandom = new();
+    static readonly Random CpnRandom = new();
 
 
     /// <summary>

--- a/YouTubeMusicAPI/Models/Search/AlbumSearchResult.cs
+++ b/YouTubeMusicAPI/Models/Search/AlbumSearchResult.cs
@@ -35,7 +35,7 @@ public class AlbumSearchResult(
     /// Weither this album is a single or not
     /// </summary>
     public bool IsSingle { get; } = isSingle;
-    
+
     /// <summary>
     /// Weither this album is an EP or not
     /// </summary>

--- a/YouTubeMusicAPI/Models/Search/SongSearchResult.cs
+++ b/YouTubeMusicAPI/Models/Search/SongSearchResult.cs
@@ -16,7 +16,7 @@ public class SongSearchResult(
     string name,
     string id,
     NamedEntity[] artists,
-    NamedEntity album,
+    NamedEntity? album,
     TimeSpan duration,
     bool isExplicit,
     string playsInfo,
@@ -31,7 +31,7 @@ public class SongSearchResult(
     /// <summary>
     /// The album of this song
     /// </summary>
-    public NamedEntity Album { get; } = album;
+    public NamedEntity? Album { get; } = album;
 
     /// <summary>
     /// The duration of this song

--- a/YouTubeMusicAPI/Models/Streaming/StreamingData.cs
+++ b/YouTubeMusicAPI/Models/Streaming/StreamingData.cs
@@ -25,7 +25,7 @@ public class StreamingData(
     /// Whether the song or video is live content or not
     /// </summary>
     public bool IsLiveContent { get; } = isLiveContent;
-    
+
     /// <summary>
     /// The amount of time the streams expire in
     /// </summary>

--- a/YouTubeMusicAPI/YouTubeMusicAPI.csproj
+++ b/YouTubeMusicAPI/YouTubeMusicAPI.csproj
@@ -6,9 +6,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<Version>3.0.2</Version>
-		<AssemblyVersion>3.0.2</AssemblyVersion>
-		<FileVersion>3.0.2</FileVersion>
+		<Version>3.0.3</Version>
+		<AssemblyVersion>3.0.3</AssemblyVersion>
+		<FileVersion>3.0.3</FileVersion>
 
 		<Title>YouTube Music API</Title>
 		<Authors>IcySnex</Authors>
@@ -25,10 +25,8 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReleaseNotes>
-			- Fixed getting streaming data when authenticated (sig deciphering extraction)
-			- Fixed general search (without SearchCategory) always being empty
-			- Fixed missing log events in RequestHelper
-			- Updated NuGet packages
+			- Fixed album getting added to artists list when getting song/video info
+			- Updated packages
 		</PackageReleaseNotes>
 	</PropertyGroup>
 	
@@ -48,9 +46,9 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Jint" Version="4.4.1" />
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+	  <PackageReference Include="Jint" Version="4.4.2" />
+	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 	

--- a/YouTubeMusicAPI/YouTubeMusicAPI.csproj
+++ b/YouTubeMusicAPI/YouTubeMusicAPI.csproj
@@ -6,9 +6,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<Version>3.0.1</Version>
-		<AssemblyVersion>3.0.1</AssemblyVersion>
-		<FileVersion>3.0.1</FileVersion>
+		<Version>3.0.2</Version>
+		<AssemblyVersion>3.0.2</AssemblyVersion>
+		<FileVersion>3.0.2</FileVersion>
 
 		<Title>YouTube Music API</Title>
 		<Authors>IcySnex</Authors>
@@ -25,7 +25,10 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReleaseNotes>
-			- Fixed that streaming URLs might be undecoded
+			- Fixed getting streaming data when authenticated (sig deciphering extraction)
+			- Fixed general search (without SearchCategory) always being empty
+			- Fixed missing log events in RequestHelper
+			- Updated NuGet packages
 		</PackageReleaseNotes>
 	</PropertyGroup>
 	
@@ -46,9 +49,9 @@
 	
 	<ItemGroup>
 	  <PackageReference Include="Jint" Version="4.4.1" />
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 	
 </Project>

--- a/YouTubeMusicAPI/YouTubeMusicAPI.csproj
+++ b/YouTubeMusicAPI/YouTubeMusicAPI.csproj
@@ -6,9 +6,9 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<Version>3.0.3</Version>
-		<AssemblyVersion>3.0.3</AssemblyVersion>
-		<FileVersion>3.0.3</FileVersion>
+		<Version>3.0.4</Version>
+		<AssemblyVersion>3.0.4</AssemblyVersion>
+		<FileVersion>3.0.4</FileVersion>
 
 		<Title>YouTube Music API</Title>
 		<Authors>IcySnex</Authors>
@@ -25,8 +25,8 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReleaseNotes>
-			- Fixed album getting added to artists list when getting song/video info
-			- Updated packages
+			- Fixed signatureTimestamp extraction logic for streaming
+			- Updated nuget packages
 		</PackageReleaseNotes>
 	</PropertyGroup>
 	
@@ -46,9 +46,9 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="Jint" Version="4.4.2" />
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+	  <PackageReference Include="Jint" Version="4.5.0" />
+	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.2" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 	


### PR DESCRIPTION
I could not validate the tests; they fail locally for me at HEAD.

Also fixed a threading issue by locking around operations on the `player` object.